### PR TITLE
Set transformers dependency to >=4.40.0 for consistency with setup.py.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.29.2
+transformers>=4.40.0
 accelerate==0.19.0
 datasets
 pysbd


### PR DESCRIPTION
Fixes #124 

Note: a more sustainable solution would be to keep dependencies only in `setup.py` and remove the `requirements.txt` file.