### PR TITLE
Relax the requirements on numpy to allow numpy 2.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     install_requires=[
         "onnxruntime>=1.13.1",
         "transformers>=4.22.2",
-        "numpy>=1.0,<2.0",
+        "numpy>=1.0",
         "scikit-learn>=1",
         "tqdm",
         "skops",


### PR DESCRIPTION
It seems that tests are passing with `numpy==2.1.0` and it works for us. Do you think there are other issues we haven't encountered?