### PR TITLE
add ONNX support for SaT models

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sat_adapted.split("This is a test This is another test.")
 🚀 You can now enable even faster ONNX inference for `sat` and `sat-sm` models! 🚀
 
 ```python
-sat = SaT("sat-3l-sm", onnx_providers=["CUDAExecutionProvider"])
+sat = SaT("sat-3l-sm", ort_providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
 ```
 
 ```python
@@ -58,15 +58,17 @@ sat = SaT("sat-3l-sm", onnx_providers=["CUDAExecutionProvider"])
 >>> texts = ["This is a sentence. This is another sentence."] * 1000
 
 # PyTorch GPU
->>> model = SaT("sat-3l-sm")
->>> model.half().to("cuda")
->>> list(model.split(texts))
+>>> model_pytorch = SaT("sat-3l-sm")
+>>> model_pytorch.half().to("cuda");
+>>> %timeit list(model_pytorch.split(texts))
+# 144 ms ± 252 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
 # quite fast already, but...
 
 # onnxruntime GPU
->>> model = SaT("sat-3l-sm", ort_providers=["CUDAExecutionProvider"])
->>> %timeit list(model.split(texts))
-# ...this should be ~50% faster!
+>>> model_ort = SaT("sat-3l-sm", ort_providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+>>> %timeit list(model_ort.split(texts))
+# 94.9 ms ± 165 μs per loop (mean ± std. dev. of 7 runs, 10 loops each
+# ...this should be ~50% faster! (tested on RTX 3090)
 ```
 
 If you wish to use LoRA in combination with an ONNX model:
@@ -74,7 +76,7 @@ If you wish to use LoRA in combination with an ONNX model:
   - If you have a local LoRA module, use `lora_path`.
   - If you wish to load a LoRA module from the HuggingFace hub, use `style_or_domain` and `language`.
 - Load the ONNX model with merged LoRA weights: 
-`sat = SaT(<OUTPUT_DIR>, onnx_providers=["CUDAExecutionProvider"])`
+`sat = SaT(<OUTPUT_DIR>, onnx_providers=["CUDAExecutionProvider", "CPUExecutionProvider"])`
 
 
 ## Available Models

--- a/README.md
+++ b/README.md
@@ -46,6 +46,36 @@ sat_adapted.split("This is a test This is another test.")
 # returns ['This is a test ', 'This is another test']
 ```
 
+## ONNX Support
+🚀 You can now enable even faster ONNX inference for `sat` and `sat-sm` models! 🚀
+
+```python
+sat = SaT("sat-3l-sm", onnx_providers=["CUDAExecutionProvider"])
+```
+
+```python
+>>> from wtpsplit import SaT
+>>> texts = ["This is a sentence. This is another sentence."] * 1000
+
+# PyTorch GPU
+>>> model = SaT("sat-3l-sm")
+>>> model.half().to("cuda")
+>>> %timeit list(model.split(texts))
+138 ms ± 8.41 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
+
+# onnxruntime GPU
+>>> model = SaT("sat-3l-sm", ort_providers=["CUDAExecutionProvider"])
+>>> %timeit list(model.split(texts))
+198 ms ± 1.36 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
+```
+
+If you wish to use LoRA in combination with an ONNX model:
+- Run `scripts/export_to_onnx_sat.py` with `use_lora: True` and an appropriate `output_dir: <OUTPUT_DIR>`.
+  - If you have a local LoRA module, use `lora_path`.
+  - If you wish to load a LoRA module from the HuggingFace hub, use `style_or_domain` and `language`.
+- Load the ONNX model with merged LoRA weights: 
+`sat = SaT(<OUTPUT_DIR>, onnx_providers=["CUDAExecutionProvider"])`
+
 
 ## Available Models
 

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ sat = SaT("sat-3l-sm", onnx_providers=["CUDAExecutionProvider"])
 # PyTorch GPU
 >>> model = SaT("sat-3l-sm")
 >>> model.half().to("cuda")
->>> %timeit list(model.split(texts))
-138 ms ± 8.41 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
+>>> list(model.split(texts))
+# quite fast already, but...
 
 # onnxruntime GPU
 >>> model = SaT("sat-3l-sm", ort_providers=["CUDAExecutionProvider"])
 >>> %timeit list(model.split(texts))
-198 ms ± 1.36 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
+# ...this should be ~50% faster!
 ```
 
 If you wish to use LoRA in combination with an ONNX model:

--- a/scripts/export_all_to_onnx.sh
+++ b/scripts/export_all_to_onnx.sh
@@ -1,0 +1,23 @@
+# all models in manually defined array of models
+models=(
+    "sat-1l-sm"
+    "sat-3l-sm"
+    "sat-6l-sm"
+    "sat-9l-sm"
+    "sat-12l-sm"
+    "sat-1l"
+    "sat-3l"
+    "sat-6l"
+    "sat-9l"
+    "sat-12l"
+    "sat-1l-no-limited-lookahead"
+    "sat-3l-no-limited-lookahead"
+    "sat-6l-no-limited-lookahead"
+    "sat-9l-no-limited-lookahead"
+    "sat-12l-no-limited-lookahead"
+)
+
+for model in "${models[@]}"
+do
+    python scripts/export_to_onnx_sat.py --model_name_or_path=segment-any-text/$model --output_dir=output_onnx_exports/$model --upload_to_hub=True
+done

--- a/scripts/export_to_onnx_sat.py
+++ b/scripts/export_to_onnx_sat.py
@@ -1,21 +1,32 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+import adapters  # noqa
 import onnx
 import torch
+from adapters.models import MODEL_MIXIN_MAPPING  # noqa
+from adapters.models.bert.mixin_bert import BertModelAdaptersMixin  # noqa
+from huggingface_hub import hf_hub_download
 from onnxruntime.transformers.optimizer import optimize_model  # noqa
 from transformers import AutoModelForTokenClassification, HfArgumentParser
 
 import wtpsplit  # noqa
 import wtpsplit.models  # noqa
+from wtpsplit.utils import Constants
+
+MODEL_MIXIN_MAPPING["SubwordXLMRobertaModel"] = BertModelAdaptersMixin
 
 
 @dataclass
 class Args:
-    model_name_or_path: str = "segment-any-text/sat-1l-sm"
-    output_dir: str = "sat-1l-sm"
+    model_name_or_path: str = "segment-any-text/sat-1l-sm"  # model from HF Hub: https://huggingface.co/segment-any-text
+    output_dir: str = "sat-1l-sm"  # output directory, saves to current directory
     device: str = "cuda"
-    # TODO: lora merging here
+    use_lora: bool = False
+    lora_path: str = None  # local path to lora weights
+    # otherwise, fetch from HF Hub:
+    style_or_domain: str = "ud"
+    language: str = "en"
 
 
 if __name__ == "__main__":
@@ -25,25 +36,70 @@ if __name__ == "__main__":
     output_dir.mkdir(exist_ok=True, parents=True)
 
     model = AutoModelForTokenClassification.from_pretrained(args.model_name_or_path, force_download=False)
-    model = model.half()  # CUDA ONLY!
+
     model = model.to(args.device)
+
+    # fetch config.json from huggingface hub
+    hf_hub_download(
+        repo_id=args.model_name_or_path,
+        filename="config.json",
+        local_dir=output_dir,
+    )
+
+    # LoRA SETUP
+    if args.use_lora:
+        # adapters need xlm-roberta as model type.
+        model_type = model.config.model_type
+        model.config.model_type = "xlm-roberta"
+        adapters.init(model)
+        # reset model type (used later)
+        model.config.model_type = model_type
+        if not args.lora_path:
+            for file in [
+                "adapter_config.json",
+                "head_config.json",
+                "pytorch_adapter.bin",
+                "pytorch_model_head.bin",
+            ]:
+                hf_hub_download(
+                    repo_id=args.model_name_or_path,
+                    subfolder=f"loras/{args.style_or_domain}/{args.language}",
+                    filename=file,
+                    local_dir=Constants.CACHE_DIR,
+                )
+            lora_load_path = str(Constants.CACHE_DIR / "loras" / args.style_or_domain / args.language)
+        else:
+            lora_load_path = args.lora_path
+
+        print(f"Using LoRA weights from {lora_load_path}.")
+        model.load_adapter(
+            lora_load_path,
+            set_active=True,
+            with_head=True,
+            load_as="sat-lora",
+        )
+        # merge lora weights into transformer for 0 efficiency overhead
+        model.merge_adapter("sat-lora")
+        print("LoRA setup done.")
+    # LoRA setup done, model is now ready for export.
+
+    model = model.half()
 
     torch.onnx.export(
         model,
         {
-            "attention_mask": torch.zeros((1, 1), dtype=torch.float16, device=args.device),
-            "input_ids": torch.zeros((1, 1), dtype=torch.int64, device=args.device),
+            "attention_mask": torch.randn((1, 1), dtype=torch.float16, device=args.device),
+            "input_ids": torch.randint(0, 250002, (1, 1), dtype=torch.int64, device=args.device),
         },
         output_dir / "model.onnx",
         verbose=True,
         input_names=["attention_mask", "input_ids"],
         output_names=["logits"],
         dynamic_axes={
-            "input_ids": {0: "batch", 1: "sequence"},
             "attention_mask": {0: "batch", 1: "sequence"},
+            "input_ids": {0: "batch", 1: "sequence"},
             "logits": {0: "batch", 1: "sequence"},
         },
-        # opset_version=11
     )
 
     m = optimize_model(
@@ -60,4 +116,4 @@ if __name__ == "__main__":
     onnx.save_model(m.model, optimized_model_path)
 
     onnx_model = onnx.load(output_dir / "model.onnx")
-    onnx.checker.check_model(onnx_model, full_check=True)
+    print(onnx.checker.check_model(onnx_model, full_check=True))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="wtpsplit",
-    version="2.0.8",
+    version="2.1.0",
     packages=find_packages(),
     description="Universal Robust, Efficient and Adaptable Sentence Segmentation",
     author="Markus Frohmann, Igor Sterner, Benjamin Minixhofer",

--- a/test.py
+++ b/test.py
@@ -2,11 +2,11 @@
 from wtpsplit import WtP, SaT
 
 
-# def test_split_ort():
-#     sat = SaT("segment-any-text/sat-3l", ort_providers=["CPUExecutionProvider"])
+def test_split_ort():
+    sat = SaT("sat-3l-sm", ort_providers=["CPUExecutionProvider"])
 
-#     splits = sat.split("This is a test sentence This is another test sentence.", threshold=0.005)
-#     assert splits == ["This is a test sentence ", "This is another test sentence."]
+    splits = sat.split("This is a test sentence This is another test sentence.", threshold=0.25)
+    assert splits == ["This is a test sentence ", "This is another test sentence."]
 
 
 def test_split_torch():

--- a/wtpsplit/__init__.py
+++ b/wtpsplit/__init__.py
@@ -453,7 +453,9 @@ class SaT:
             else:
                 # no need to load if no ort_providers set
                 if ort_providers is not None:
-                    onnx_path = cached_file(model_name_to_fetch, "model_optimized.onnx", **(from_pretrained_kwargs or {}))
+                    onnx_path = cached_file(
+                        model_name_to_fetch, "model_optimized.onnx", **(from_pretrained_kwargs or {})
+                    )
                 else:
                     onnx_path = None
 
@@ -790,12 +792,3 @@ class SaT:
                     text, np.where(probs > sentence_threshold)[0], strip_whitespace=strip_whitespace
                 )
                 yield sentences
-
-
-if __name__ == "__main__":
-    sat = SaT("sat-3l-lora", ort_providers=["CPUExecutionProvider"])
-    print(sat.split("Hello, World! Next."))
-
-    wtp = WtP("wtp-bert-tiny", ort_providers=["CPUExecutionProvider"])
-    print(wtp.split("Hello, World! Next."))
-    print("DONE!")

--- a/wtpsplit/extract.py
+++ b/wtpsplit/extract.py
@@ -43,11 +43,11 @@ class SaTORTWrapper:
 
     def __call__(self, input_ids, attention_mask):
         logits = self.ort_session.run(
-            output_names=["logits"],
-            input_feed={
-                "attention_mask": attention_mask.astype(np.int64),
-                "input_ids": input_ids.astype(np.float16),
-            },  # .astype(np.int64)},
+            ["logits"],
+            {
+                self.ort_session.get_inputs()[0].name: input_ids.astype(np.int64),
+                self.ort_session.get_inputs()[1].name: attention_mask.astype(np.float16),
+            },
         )[0]
 
         return {"logits": logits}

--- a/wtpsplit/extract.py
+++ b/wtpsplit/extract.py
@@ -45,8 +45,8 @@ class SaTORTWrapper:
         logits = self.ort_session.run(
             ["logits"],
             {
-                self.ort_session.get_inputs()[0].name: input_ids.astype(np.int64),
-                self.ort_session.get_inputs()[1].name: attention_mask.astype(np.float16),
+                "attention_mask": attention_mask.astype(np.float16),
+                "input_ids": input_ids.astype(np.int64),
             },
         )[0]
 


### PR DESCRIPTION
This adds ONNX support for sat, sat-sm, and sat-lora models, and includes documentation and testing.

TODOs:
- Use correct timings in the README. Current ones for ONNX are incorrect because I can't access a device with onnxruntime-gpu support. Can you @bminixhofer?
- Is it fine to use `model_optimized.onnx`?
- [WIP] ONNX weights upload to HF Hub for easy loading.
- Why do we need to reverse the input_names in `extract.py`? It works but it is quite weird.