### PR TITLE
Avoid unnecessary __len__ check by using is None for tokenizer

### DIFF
--- a/wtpsplit/extract.py
+++ b/wtpsplit/extract.py
@@ -108,7 +108,7 @@ def extract(
     """
     if "xlm" in model.config.model_type:
         use_subwords = True
-        if not tokenizer:
+        if tokenizer is None:
             tokenizer = AutoTokenizer.from_pretrained(
                 "facebookAI/xlm-roberta-base",
             )


### PR DESCRIPTION
This PR replaces if not tokenizer: with if tokenizer is None: to avoid unnecessary calls to the tokenizer’s __len__ method, improving efficiency.

```python
# PyTorch GPU
>>> sat_sm = SaT("sat-3l-sm")
>>> sat_sm.half().to("cuda") # optional, see above
>>> text = "this is a test this is another test"
>>> %timeit list(sat_sm.split(text))
# 52.7 ms ± 2.16 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# PR Patch PyTorch GPU
>>> %timeit list(sat_sm.split(text))
# 2.45 ms ± 24.1 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# ONNX CPU
>>> model_ort = SaT("sat-3l-sm", ort_providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
>>> %timeit list(model_ort.split(text))
# 59.3 ms ± 1.83 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# PR Patch ONNX CPU
>>> %timeit list(model_ort.split(text))
# 14.7 ms ± 699 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

```

When executing if not tokenizer:, the [__len__ special method](https://github.com/huggingface/transformers/blob/222505c7e4d08da9095d12ddb72fb653f4b6da33/src/transformers/tokenization_utils_fast.py#L275-L279) of the corresponding class is triggered, incurring a fixed overhead of approximately 40ms.

To avoid this overhead, we use a direct None check to determine the presence of the tokenizer, eliminating this bottleneck.