### PR TITLE
Improve postprocessing efficiency

### DIFF
--- a/wtpsplit/__init__.py
+++ b/wtpsplit/__init__.py
@@ -465,6 +465,7 @@ class SaT:
         self.use_lora = False
 
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path)
+        self.special_tokens = [self.tokenizer.cls_token, self.tokenizer.sep_token, self.tokenizer.pad_token]
 
         if isinstance(model_name_or_model, (str, Path)):
             model_name = str(model_name_or_model)
@@ -691,7 +692,7 @@ class SaT:
                         input_texts[i],
                         tokenizer_output["input_ids"][i],
                         outer_batch_logits[i],
-                        tokenizer,
+                        self.special_tokens,
                         tokenizer_output["offset_mapping"][i],
                     )
                     for i in range(len(input_texts))

--- a/wtpsplit/evaluation/adapt.py
+++ b/wtpsplit/evaluation/adapt.py
@@ -111,8 +111,10 @@ def process_logits(text, model, lang_code, args):
         if "xlm" in model.config.model_type:
             tokens = tokenizer.tokenize(text, verbose=False)
 
+            special_tokens = [tokenizer.cls_token, tokenizer.sep_token, tokenizer.pad_token]
+
             # convert token probabilities to character probabilities for the entire array
-            char_probs = token_to_char_probs(text, tokens, logits, tokenizer, offsets_mapping)
+            char_probs = token_to_char_probs(text, tokens, logits, special_tokens, offsets_mapping)
 
             logits = char_probs
 

--- a/wtpsplit/evaluation/adapt.py
+++ b/wtpsplit/evaluation/adapt.py
@@ -88,7 +88,13 @@ def process_logits(text, model, lang_code, args):
             if "xlm" in model.config.model_type:
                 tokens = tokenizer.tokenize(short_seq, verbose=False)
 
-                char_probs = token_to_char_probs(short_seq, tokens, current_logits, tokenizer, current_offsets_mapping)
+                char_probs = token_to_char_probs(
+                    short_seq,
+                    tokens,
+                    current_logits,
+                    [tokenizer.cls_token, tokenizer.sep_token, tokenizer.pad_token],
+                    current_offsets_mapping,
+                )
 
                 current_logits = char_probs
 

--- a/wtpsplit/evaluation/intrinsic_pairwise.py
+++ b/wtpsplit/evaluation/intrinsic_pairwise.py
@@ -90,8 +90,10 @@ def process_logits_k_mers(pairs, model, lang_code, block_size, batch_size, verbo
             if "xlm" in model.config.model_type:
                 tokens = tokenizer.tokenize(k_mer, verbose=False)
 
+                special_tokens = [tokenizer.cls_token, tokenizer.sep_token, tokenizer.pad_token]
+
                 # padding is also removed here (via offset_mapping)
-                logits = token_to_char_probs(k_mer, tokens, logit, tokenizer, offset_mapping)
+                logits = token_to_char_probs(k_mer, tokens, logit, special_tokens, offset_mapping)
                 logits_list.append(logits)
                 n_tokens_list.append(len(tokens))
             else:

--- a/wtpsplit/evaluation/intrinsic_pairwise.py
+++ b/wtpsplit/evaluation/intrinsic_pairwise.py
@@ -86,11 +86,11 @@ def process_logits_k_mers(pairs, model, lang_code, block_size, batch_size, verbo
             pad_last_batch=True,
         )
 
+        special_tokens = [tokenizer.cls_token, tokenizer.sep_token, tokenizer.pad_token]
+
         for k_mer, logit, offset_mapping in zip(k_mer_texts, all_logits, offsets_mapping):
             if "xlm" in model.config.model_type:
                 tokens = tokenizer.tokenize(k_mer, verbose=False)
-
-                special_tokens = [tokenizer.cls_token, tokenizer.sep_token, tokenizer.pad_token]
 
                 # padding is also removed here (via offset_mapping)
                 logits = token_to_char_probs(k_mer, tokens, logit, special_tokens, offset_mapping)

--- a/wtpsplit/train/evaluate.py
+++ b/wtpsplit/train/evaluate.py
@@ -111,7 +111,9 @@ def evaluate_sentence(
 
     if "xlm" in model.config.model_type:
         tokens = tokenizer.tokenize(text, verbose=False)
-        char_probs = token_to_char_probs(text, tokens, logits, tokenizer, offsets_mapping)
+        char_probs = token_to_char_probs(
+            text, tokens, logits, [tokenizer.cls_token, tokenizer.sep_token, tokenizer.pad_token], offsets_mapping
+        )
     else:
         char_probs = logits
     newline_probs = char_probs[:, positive_index]

--- a/wtpsplit/utils/__init__.py
+++ b/wtpsplit/utils/__init__.py
@@ -449,9 +449,7 @@ def token_to_char_probs(text, tokens, token_logits, special_tokens, offsets_mapp
     valid_indices, valid_offsets = get_token_spans(offsets_mapping, tokens, special_tokens)
 
     # Assign the token's probability to the last character of the token
-    for i in range(valid_offsets.shape[0]):
-        start, end = valid_offsets[i]
-        char_probs[end - 1] = token_logits[valid_indices[i]]
+    char_probs[valid_offsets[:, 1] - 1] = token_logits[valid_indices]
 
     return char_probs
 

--- a/wtpsplit/utils/__init__.py
+++ b/wtpsplit/utils/__init__.py
@@ -449,6 +449,8 @@ def token_to_char_probs(text, tokens, token_logits, special_tokens, offsets_mapp
     valid_indices, valid_offsets = get_token_spans(offsets_mapping, tokens, special_tokens)
 
     # Assign the token's probability to the last character of the token
+    # Here, `valid_offsets[:, 1] - 1` computes the index of the last character for each token,
+    # and `token_logits[valid_indices]` provides the corresponding probabilities for those tokens.
     char_probs[valid_offsets[:, 1] - 1] = token_logits[valid_indices]
 
     return char_probs

--- a/wtpsplit/utils/__init__.py
+++ b/wtpsplit/utils/__init__.py
@@ -433,25 +433,20 @@ def reconstruct_sentences(text, partial_sentences):
     return fixed_sentences
 
 
-def get_token_spans(tokenizer, offsets_mapping, tokens):
+def get_token_spans(offsets_mapping, tokens, special_tokens):
     # Filter out special tokens and get their character start and end positions
     valid_indices = np.array(
-        [
-            idx
-            for idx, token in enumerate(tokens)
-            if token not in [tokenizer.cls_token, tokenizer.sep_token, tokenizer.pad_token]
-            and idx < len(offsets_mapping)
-        ]
+        [idx for idx, token in enumerate(tokens) if idx < len(offsets_mapping) and token not in special_tokens]
     )
     valid_offsets = np.array(offsets_mapping)[valid_indices]
     return valid_indices, valid_offsets
 
 
-def token_to_char_probs(text, tokens, token_logits, tokenizer, offsets_mapping):
+def token_to_char_probs(text, tokens, token_logits, special_tokens, offsets_mapping):
     """Map from token probabalities to character probabilities"""
     char_probs = np.full((len(text), token_logits.shape[1]), -np.inf)  # Initialize with very low numbers
 
-    valid_indices, valid_offsets = get_token_spans(tokenizer, offsets_mapping, tokens)
+    valid_indices, valid_offsets = get_token_spans(offsets_mapping, tokens, special_tokens)
 
     # Assign the token's probability to the last character of the token
     for i in range(valid_offsets.shape[0]):

--- a/wtpsplit/utils/__init__.py
+++ b/wtpsplit/utils/__init__.py
@@ -443,7 +443,7 @@ def get_token_spans(offsets_mapping, tokens, special_tokens):
 
 
 def token_to_char_probs(text, tokens, token_logits, special_tokens, offsets_mapping):
-    """Map from token probabalities to character probabilities"""
+    """Map from token probabilities to character probabilities"""
     char_probs = np.full((len(text), token_logits.shape[1]), -np.inf)  # Initialize with very low numbers
 
     valid_indices, valid_offsets = get_token_spans(offsets_mapping, tokens, special_tokens)


### PR DESCRIPTION
This PR makes a couple of small refactors to improve performance with processing logits. On an L40S, this translates to a ~3x speed improvement.

1. In `get_token_spans`, `getattr` calls to `tokenizer.cls_token, tokenizer.sep_token, tokenizer.pad_token` dominate and are replaced with a one-time definition when the tokenizer is first instantiated.
2. In `token_to_char_probs`, assignment of `char_probs` is replaced with vectorized indexing instead of a for loop.

Traces from pyinstrument:

Before:
<img width="1285" alt="Screenshot 2025-06-06 at 16 51 44" src="https://github.com/user-attachments/assets/6e6891d3-ed15-4776-895d-42bdfd206058" />

After:
<img width="1252" alt="Screenshot 2025-06-06 at 16 50 03" src="https://github.com/user-attachments/assets/2f5943cd-f094-4908-8397-29712adada34" />
